### PR TITLE
HBX-3349: Update Maven version to 3.9.13

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.13/apache-maven-3.9.13-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
     <properties>
 
-        <maven.version>3.9.12</maven.version>
+        <maven.version>3.9.13</maven.version>
 
         <ant.version>1.10.15</ant.version>
         <commons-collections.version>4.5.0</commons-collections.version>
@@ -99,7 +99,7 @@
         <hibernate-asciidoctor-theme.version>6.1.2.Final</hibernate-asciidoctor-theme.version>
 
         <!-- Plugins not managed by the JBoss parent POM: -->
-        <maven-plugin-api.version>3.9.12</maven-plugin-api.version>
+        <maven-plugin-api.version>3.9.13</maven-plugin-api.version>
         <maven-plugin-annotations.version>3.15.2</maven-plugin-annotations.version>
         <maven-wrapper-plugin.version>3.3.4</maven-wrapper-plugin.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
@@ -128,7 +128,6 @@
         <central.snapshots.repo.url>https://central.sonatype.com/repository/maven-snapshots/</central.snapshots.repo.url>
 
         <maven.compiler.release>8</maven.compiler.release>
-        <maven.min.version>${maven.version}</maven.min.version>
         <maven-core.version>${maven.version}</maven-core.version>
 
     </properties>
@@ -292,7 +291,7 @@
                     <artifactId>maven-wrapper-plugin</artifactId>
                     <version>${maven-wrapper-plugin.version}</version>
                     <configuration>
-                        <mavenVersion>${maven.min.version}</mavenVersion>
+                        <mavenVersion>${maven.version}</mavenVersion>
                         <distributionType>bin</distributionType>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Summary
- Update `maven.version` and `maven-plugin-api.version` from 3.9.12 to 3.9.13
- Remove redundant `maven.min.version` property, replaced with direct use of `maven.version`
- Update Maven wrapper to download Maven 3.9.13